### PR TITLE
feat: make strategies expandable

### DIFF
--- a/contracts/StrategyManager.sol
+++ b/contracts/StrategyManager.sol
@@ -18,24 +18,21 @@ import {UseZap} from "./abstract/UseZap.sol";
 contract StrategyManager is HubOwnable, UseTreasury, UseZap {
     using SafeERC20Upgradeable for IERC20Upgradeable;
 
-    struct DcaStrategy {
+    struct DcaInvestment {
         uint208 poolId;
         uint16 swaps;
         uint8 percentage;
     }
 
-    struct VaultStrategy {
+    struct VaultInvestment {
         address vault;
         uint8 percentage;
     }
 
     struct Strategy {
         address creator;
-        uint totalDeposits;
         uint8 dcaPercentage;
         uint8 vaultPercentage;
-        DcaStrategy[] dcaInvestments;
-        VaultStrategy[] vaultInvestments;
     }
 
     struct VaultPosition {
@@ -63,6 +60,13 @@ contract StrategyManager is HubOwnable, UseTreasury, UseZap {
         uint8 maxHottestStrategies;
         uint32 strategistPercentage;
         uint32 hotStrategistPercentage;
+    }
+
+    struct CreateStrategyParams {
+        DcaInvestment[] dcaInvestments;
+        VaultInvestment[] vaultInvestments;
+        SubscriptionManager.Permit permit;
+        bytes32 metadataHash;
     }
 
     /**
@@ -101,7 +105,10 @@ contract StrategyManager is HubOwnable, UseTreasury, UseZap {
 
     mapping(address => Position[]) internal _positions;
     mapping(address => uint) internal _strategistRewards;
+
     Strategy[] internal _strategies;
+    mapping(uint => DcaInvestment[]) internal _dcaInvestmentsPerStrategy;
+    mapping(uint => VaultInvestment[]) internal _vaultInvestmentsPerStrategy;
 
     IERC20Upgradeable public stable;
     SubscriptionManager public subscriptionManager;
@@ -162,15 +169,10 @@ contract StrategyManager is HubOwnable, UseTreasury, UseZap {
         vaultManager = _initializeParams.vaultManager;
     }
 
-    function createStrategy(
-        DcaStrategy[] memory _dcaInvestments,
-        VaultStrategy[] memory _vaultInvestments,
-        SubscriptionManager.Permit calldata _permit,
-        bytes32 metadataHash
-    ) external virtual {
-        uint investmentCount = _dcaInvestments.length + _vaultInvestments.length;
+    function createStrategy(CreateStrategyParams memory _params) external virtual {
+        uint investmentCount = _params.dcaInvestments.length + _params.vaultInvestments.length;
 
-        if (!subscriptionManager.isSubscribed(msg.sender, _permit))
+        if (!subscriptionManager.isSubscribed(msg.sender, _params.permit))
             revert Unauthorized();
 
         if (investmentCount > 20)
@@ -179,14 +181,16 @@ contract StrategyManager is HubOwnable, UseTreasury, UseZap {
         uint8 dcaPercentage;
         uint8 vaultPercentage;
 
-        for (uint i = 0; i < _dcaInvestments.length; i++)
-            dcaPercentage += _dcaInvestments[i].percentage;
+        for (uint i = 0; i < _params.dcaInvestments.length; i++)
+            dcaPercentage += _params.dcaInvestments[i].percentage;
 
-        for (uint i = 0; i < _vaultInvestments.length; i++)
-            vaultPercentage += _vaultInvestments[i].percentage;
+        for (uint i = 0; i < _params.vaultInvestments.length; i++)
+            vaultPercentage += _params.vaultInvestments[i].percentage;
 
         if ((dcaPercentage + vaultPercentage) != 100)
             revert InvalidTotalPercentage();
+
+        uint strategyId = _strategies.length;
 
         Strategy storage strategy = _strategies.push();
         strategy.creator = msg.sender;
@@ -194,25 +198,25 @@ contract StrategyManager is HubOwnable, UseTreasury, UseZap {
         strategy.vaultPercentage = vaultPercentage;
 
         // Assigning isn't possible because you can't convert an array of structs from memory to storage
-        for (uint i = 0; i < _dcaInvestments.length; i++) {
-            DcaStrategy memory dcaStrategy = _dcaInvestments[i];
+        for (uint i = 0; i < _params.dcaInvestments.length; i++) {
+            DcaInvestment memory dcaStrategy = _params.dcaInvestments[i];
 
             if (dcaStrategy.poolId >= dca.getPoolsLength())
                 revert InvalidInvestment();
 
-            strategy.dcaInvestments.push(dcaStrategy);
+            _dcaInvestmentsPerStrategy[strategyId].push(dcaStrategy);
         }
 
-        for (uint i = 0; i < _vaultInvestments.length; i++) {
-            VaultStrategy memory vaultStrategy = _vaultInvestments[i];
+        for (uint i = 0; i < _params.vaultInvestments.length; i++) {
+            VaultInvestment memory vaultStrategy = _params.vaultInvestments[i];
 
             if (!vaultManager.whitelistedVaults(vaultStrategy.vault))
                 revert InvalidInvestment();
 
-            strategy.vaultInvestments.push(vaultStrategy);
+            _vaultInvestmentsPerStrategy[strategyId].push(vaultStrategy);
         }
 
-        emit StrategyCreated(msg.sender, _strategies.length - 1, metadataHash);
+        emit StrategyCreated(msg.sender, strategyId, _params.metadataHash);
     }
 
     function invest(InvestParams calldata _params) external virtual {
@@ -253,8 +257,6 @@ contract StrategyManager is HubOwnable, UseTreasury, UseZap {
         );
 
         _updateDust(stable, initialBalance + pullFundsResult.strategistFee);
-
-        strategy.totalDeposits += _params.inputAmount;
 
         uint positionId = _positions[msg.sender].length;
 
@@ -423,6 +425,15 @@ contract StrategyManager is HubOwnable, UseTreasury, UseZap {
         return _strategies[_strategyId];
     }
 
+    function getStrategyInvestments(
+        uint _strategyId
+    ) external virtual view returns (
+        DcaInvestment[] memory dcaInvestments,
+        VaultInvestment[] memory vaultInvestments
+    ) {
+        return (_dcaInvestmentsPerStrategy[_strategyId], _vaultInvestmentsPerStrategy[_strategyId]);
+    }
+
     function getStrategiesLength() external virtual view returns (uint) {
         return _strategies.length;
     }
@@ -469,19 +480,19 @@ contract StrategyManager is HubOwnable, UseTreasury, UseZap {
     function _investInDca(
         InvestInProductParams memory _params
     ) internal virtual returns (uint[] memory) {
-        Strategy memory strategy = _strategies[_params.strategyId];
+        DcaInvestment[] memory dcaInvestments = _dcaInvestmentsPerStrategy[_params.strategyId];
 
-        if (strategy.dcaInvestments.length == 0)
+        if (dcaInvestments.length == 0)
             return new uint[](0);
 
-        if (_params.swaps.length != strategy.dcaInvestments.length)
+        if (_params.swaps.length != dcaInvestments.length)
             revert InvalidSwapsLength();
 
-        uint[] memory dcaPositionIds = new uint[](strategy.dcaInvestments.length);
+        uint[] memory dcaPositionIds = new uint[](dcaInvestments.length);
         uint nextDcaPositionId = dca.getPositionsLength(address(this));
 
-        for (uint i = 0; i < strategy.dcaInvestments.length; i++) {
-            DcaStrategy memory investment = strategy.dcaInvestments[i];
+        for (uint i = 0; i < dcaInvestments.length; i++) {
+            DcaInvestment memory investment = dcaInvestments[i];
             IERC20Upgradeable inputToken = IERC20Upgradeable(dca.getPool(investment.poolId).inputToken);
 
             uint swapOutput = _zap(
@@ -505,18 +516,18 @@ contract StrategyManager is HubOwnable, UseTreasury, UseZap {
     function _investInVaults(
         InvestInProductParams memory _params
     ) internal virtual returns (VaultPosition[] memory) {
-        Strategy memory strategy = _strategies[_params.strategyId];
+        VaultInvestment[] memory vaultInvestments = _vaultInvestmentsPerStrategy[_params.strategyId];
 
-        if (strategy.vaultInvestments.length == 0)
+        if (vaultInvestments.length == 0)
             return new VaultPosition[](0);
 
-        if (_params.swaps.length != strategy.vaultInvestments.length)
+        if (_params.swaps.length != vaultInvestments.length)
             revert InvalidSwapsLength();
 
-        VaultPosition[] memory vaultPositions = new VaultPosition[](strategy.vaultInvestments.length);
+        VaultPosition[] memory vaultPositions = new VaultPosition[](vaultInvestments.length);
 
-        for (uint i = 0; i < strategy.vaultInvestments.length; i++) {
-            VaultStrategy memory investment = strategy.vaultInvestments[i];
+        for (uint i = 0; i < vaultInvestments.length; i++) {
+            VaultInvestment memory investment = vaultInvestments[i];
             IBeefyVaultV7 vault = IBeefyVaultV7(investment.vault);
             IERC20Upgradeable inputToken = vault.want();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
                 "@uniswap/v3-core": "^1.0.1",
                 "@uniswap/v3-periphery": "^1.4.4",
                 "eslint": "^8.52.0",
-                "hardhat": "^2.19.0",
+                "hardhat": "^2.22.5",
                 "ts-loader": "^9.5.1",
                 "ts-node": "^10.9.1",
                 "tsconfig-paths": "^4.2.0",
@@ -1460,123 +1460,74 @@
             }
         },
         "node_modules/@nomicfoundation/edr": {
-            "version": "0.3.7",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.3.7.tgz",
-            "integrity": "sha512-v2JFWnFKRsnOa6PDUrD+sr8amcdhxnG/YbL7LzmgRGU1odWEyOF4/EwNeUajQr4ZNKVWrYnJ6XjydXtUge5OBQ==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.4.0.tgz",
+            "integrity": "sha512-T96DMSogO8TCdbKKctvxfsDljbhFOUKWc9fHJhSeUh71EEho2qR4951LKQF7t7UWEzguVYh/idQr5L/E3QeaMw==",
+            "dependencies": {
+                "@nomicfoundation/edr-darwin-arm64": "0.4.0",
+                "@nomicfoundation/edr-darwin-x64": "0.4.0",
+                "@nomicfoundation/edr-linux-arm64-gnu": "0.4.0",
+                "@nomicfoundation/edr-linux-arm64-musl": "0.4.0",
+                "@nomicfoundation/edr-linux-x64-gnu": "0.4.0",
+                "@nomicfoundation/edr-linux-x64-musl": "0.4.0",
+                "@nomicfoundation/edr-win32-x64-msvc": "0.4.0"
+            },
             "engines": {
                 "node": ">= 18"
-            },
-            "optionalDependencies": {
-                "@nomicfoundation/edr-darwin-arm64": "0.3.7",
-                "@nomicfoundation/edr-darwin-x64": "0.3.7",
-                "@nomicfoundation/edr-linux-arm64-gnu": "0.3.7",
-                "@nomicfoundation/edr-linux-arm64-musl": "0.3.7",
-                "@nomicfoundation/edr-linux-x64-gnu": "0.3.7",
-                "@nomicfoundation/edr-linux-x64-musl": "0.3.7",
-                "@nomicfoundation/edr-win32-x64-msvc": "0.3.7"
             }
         },
         "node_modules/@nomicfoundation/edr-darwin-arm64": {
-            "version": "0.3.7",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.3.7.tgz",
-            "integrity": "sha512-6tK9Lv/lSfyBvpEQ4nsTfgxyDT1y1Uv/x8Wa+aB+E8qGo3ToexQ1BMVjxJk6PChXCDOWxB3B4KhqaZFjdhl3Ow==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.4.0.tgz",
+            "integrity": "sha512-7+rraFk9tCqvfemv9Ita5vTlSBAeO/S5aDKOgGRgYt0JEKZlrX161nDW6UfzMPxWl9GOLEDUzCEaYuNmXseUlg==",
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@nomicfoundation/edr-darwin-x64": {
-            "version": "0.3.7",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.3.7.tgz",
-            "integrity": "sha512-1RrQ/1JPwxrYO69e0tglFv5H+ggour5Ii3bb727+yBpBShrxtOTQ7fZyfxA5h62LCN+0Z9wYOPeQ7XFcVurMaQ==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.4.0.tgz",
+            "integrity": "sha512-+Hrc0mP9L6vhICJSfyGo/2taOToy1AIzVZawO3lU8Lf7oDQXfhQ4UkZnkWAs9SVu1eUwHUGGGE0qB8644piYgg==",
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@nomicfoundation/edr-linux-arm64-gnu": {
-            "version": "0.3.7",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.3.7.tgz",
-            "integrity": "sha512-ds/CKlBoVXIihjhflhgPn13EdKWed6r5bgvMs/YwRqT5wldQAQJZWAfA2+nYm0Yi2gMGh1RUpBcfkyl4pq7G+g==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.4.0.tgz",
+            "integrity": "sha512-4HUDMchNClQrVRfVTqBeSX92hM/3khCgpZkXP52qrnJPqgbdCxosOehlQYZ65wu0b/kaaZSyvACgvCLSQ5oSzQ==",
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@nomicfoundation/edr-linux-arm64-musl": {
-            "version": "0.3.7",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.3.7.tgz",
-            "integrity": "sha512-e29udiRaPujhLkM3+R6ju7QISrcyOqpcaxb2FsDWBkuD7H8uU9JPZEyyUIpEp5uIY0Jh1eEJPKZKIXQmQAEAuw==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.4.0.tgz",
+            "integrity": "sha512-D4J935ZRL8xfnP3zIFlCI9jXInJ0loDUkCTLeCEbOf2uuDumWDghKNQlF1itUS+EHaR1pFVBbuwqq8hVK0dASg==",
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@nomicfoundation/edr-linux-x64-gnu": {
-            "version": "0.3.7",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.3.7.tgz",
-            "integrity": "sha512-/xkjmTyv+bbJ4akBCW0qzFKxPOV4AqLOmqurov+s9umHb16oOv72osSa3SdzJED2gHDaKmpMITT4crxbar4Axg==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.4.0.tgz",
+            "integrity": "sha512-6x7HPy+uN5Cb9N77e2XMmT6+QSJ+7mRbHnhkGJ8jm4cZvWuj2Io7npOaeHQ3YHK+TiQpTnlbkjoOIpEwpY3XZA==",
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@nomicfoundation/edr-linux-x64-musl": {
-            "version": "0.3.7",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.3.7.tgz",
-            "integrity": "sha512-QwBP9xlmsbf/ldZDGLcE4QiAb8Zt46E/+WLpxHBATFhGa7MrpJh6Zse+h2VlrT/SYLPbh2cpHgSmoSlqVxWG9g==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.4.0.tgz",
+            "integrity": "sha512-3HFIJSXgyubOiaN4MWGXx2xhTnhwlJk0PiSYNf9+L/fjBtcRkb2nM910ZJHTvqCb6OT98cUnaKuAYdXIW2amgw==",
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@nomicfoundation/edr-win32-x64-msvc": {
-            "version": "0.3.7",
-            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.3.7.tgz",
-            "integrity": "sha512-j/80DEnkxrF2ewdbk/gQ2EOPvgF0XSsg8D0o4+6cKhUVAW6XwtWKzIphNL6dyD2YaWEPgIrNvqiJK/aln0ww4Q==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "win32"
-            ],
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.4.0.tgz",
+            "integrity": "sha512-CP4GsllEfXEz+lidcGYxKe5rDJ60TM5/blB5z/04ELVvw6/CK9eLcYeku7HV0jvV7VE6dADYKSdQyUkvd0El+A==",
             "engines": {
                 "node": ">= 18"
             }
@@ -8914,13 +8865,13 @@
             }
         },
         "node_modules/hardhat": {
-            "version": "2.22.3",
-            "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.3.tgz",
-            "integrity": "sha512-k8JV2ECWNchD6ahkg2BR5wKVxY0OiKot7fuxiIpRK0frRqyOljcR2vKwgWSLw6YIeDcNNA4xybj7Og7NSxr2hA==",
+            "version": "2.22.5",
+            "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.5.tgz",
+            "integrity": "sha512-9Zq+HonbXCSy6/a13GY1cgHglQRfh4qkzmj1tpPlhxJDwNVnhxlReV6K7hCWFKlOrV13EQwsdcD0rjcaQKWRZw==",
             "dependencies": {
                 "@ethersproject/abi": "^5.1.2",
                 "@metamask/eth-sig-util": "^4.0.0",
-                "@nomicfoundation/edr": "^0.3.5",
+                "@nomicfoundation/edr": "^0.4.0",
                 "@nomicfoundation/ethereumjs-common": "4.0.4",
                 "@nomicfoundation/ethereumjs-tx": "5.0.4",
                 "@nomicfoundation/ethereumjs-util": "9.0.4",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "@uniswap/v3-core": "^1.0.1",
         "@uniswap/v3-periphery": "^1.4.4",
         "eslint": "^8.52.0",
-        "hardhat": "^2.19.0",
+        "hardhat": "^2.22.5",
         "ts-loader": "^9.5.1",
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.2.0",

--- a/test/StrategyManager/createStrategy.test.ts
+++ b/test/StrategyManager/createStrategy.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { Signer, keccak256 } from 'ethers'
+import { Signer, keccak256, ContractTransactionResponse } from 'ethers'
 import { StrategyManager } from '@src/typechain'
 import { SubscriptionSignature } from '@src/SubscriptionSignature'
 import { NetworkService } from '@src/NetworkService'
@@ -21,8 +21,8 @@ describe('StrategyManager#createStrategy', () => {
     let account0: Signer
     let account1: Signer
     let strategyManager: StrategyManager
-    let dcaStrategyPositions: StrategyManager.DcaStrategyStruct[]
-    let vaultStrategyPosition: StrategyManager.VaultStrategyStruct[]
+    let dcaStrategyPositions: StrategyManager.DcaInvestmentStruct[]
+    let vaultStrategyPosition: StrategyManager.VaultInvestmentStruct[]
     let subscriptionSignature: SubscriptionSignature
     let deadline: number
     const nameBioHash = keccak256(new TextEncoder().encode('Name' + 'Bio'))
@@ -41,42 +41,38 @@ describe('StrategyManager#createStrategy', () => {
     })
 
     describe('EFFECTS', async () => {
-        it('creates new strategy', async () => {
-            await strategyManager.connect(account0).createStrategy(
-                dcaStrategyPositions,
-                vaultStrategyPosition,
-                await subscriptionSignature.signSubscriptionPermit(
+        let tx: Promise<ContractTransactionResponse>
+
+        beforeEach(async () => {
+            tx = strategyManager.connect(account0).createStrategy({
+                dcaInvestments: dcaStrategyPositions,
+                vaultInvestments: vaultStrategyPosition,
+                permit: await subscriptionSignature.signSubscriptionPermit(
                     await account0.getAddress(),
-                    deadline,
+                    await NetworkService.getBlockTimestamp() + 10_000,
                 ),
-                nameBioHash,
-            )
+                metadataHash: nameBioHash,
+            })
+        })
 
-            const strategy = await strategyManager.getStrategy(0)
+        it('creates new strategy', async () => {
+            await tx
 
-            expect(strategy.dcaInvestments[0].swaps).to.be.equal(dcaStrategyPositions[0].swaps)
-            expect(strategy.dcaInvestments[0].poolId).to.be.equal(dcaStrategyPositions[0].poolId)
-            expect(strategy.dcaInvestments[0].percentage).to.be.equal(dcaStrategyPositions[0].percentage)
+            const investments = await strategyManager.getStrategyInvestments(0)
 
-            expect(strategy.dcaInvestments[1].swaps).to.be.equal(dcaStrategyPositions[1].swaps)
-            expect(strategy.dcaInvestments[1].poolId).to.be.equal(dcaStrategyPositions[1].poolId)
-            expect(strategy.dcaInvestments[1].percentage).to.be.equal(dcaStrategyPositions[1].percentage)
+            expect(investments.dcaInvestments[0].swaps).to.be.equal(dcaStrategyPositions[0].swaps)
+            expect(investments.dcaInvestments[0].poolId).to.be.equal(dcaStrategyPositions[0].poolId)
+            expect(investments.dcaInvestments[0].percentage).to.be.equal(dcaStrategyPositions[0].percentage)
 
-            expect(strategy.vaultInvestments[0].vault).to.be.equal(vaultStrategyPosition[0].vault)
-            expect(strategy.vaultInvestments[0].percentage).to.be.equal(vaultStrategyPosition[0].percentage)
+            expect(investments.dcaInvestments[1].swaps).to.be.equal(dcaStrategyPositions[1].swaps)
+            expect(investments.dcaInvestments[1].poolId).to.be.equal(dcaStrategyPositions[1].poolId)
+            expect(investments.dcaInvestments[1].percentage).to.be.equal(dcaStrategyPositions[1].percentage)
+
+            expect(investments.vaultInvestments[0].vault).to.be.equal(vaultStrategyPosition[0].vault)
+            expect(investments.vaultInvestments[0].percentage).to.be.equal(vaultStrategyPosition[0].percentage)
         })
 
         it('emit StrategyCreated', async () => {
-            const tx = strategyManager.connect(account0).createStrategy(
-                dcaStrategyPositions,
-                vaultStrategyPosition,
-                await subscriptionSignature.signSubscriptionPermit(
-                    await account0.getAddress(),
-                    deadline,
-                ),
-                nameBioHash,
-            )
-
             await expect(tx)
                 .to.emit(strategyManager, 'StrategyCreated')
                 .withArgs(
@@ -91,15 +87,15 @@ describe('StrategyManager#createStrategy', () => {
         it('increases strategy count', async () => {
             expect(await strategyManager.getStrategiesLength()).to.be.equal(0)
 
-            await strategyManager.connect(account0).createStrategy(
-                dcaStrategyPositions,
-                vaultStrategyPosition,
-                await subscriptionSignature.signSubscriptionPermit(
+            await strategyManager.connect(account0).createStrategy({
+                dcaInvestments: dcaStrategyPositions,
+                vaultInvestments: vaultStrategyPosition,
+                permit: await subscriptionSignature.signSubscriptionPermit(
                     await account0.getAddress(),
                     deadline,
                 ),
-                nameBioHash,
-            )
+                metadataHash: nameBioHash,
+            })
 
             expect(await strategyManager.getStrategiesLength()).to.be.equal(1)
         })
@@ -107,21 +103,21 @@ describe('StrategyManager#createStrategy', () => {
 
     describe('REVERTS', () => {
         it('if msg.sender doenst have an active subscription', async () => {
-            const tx = strategyManager.connect(account1).createStrategy(
-                dcaStrategyPositions,
-                vaultStrategyPosition,
-                await subscriptionSignature.signSubscriptionPermit(
+            const tx = strategyManager.connect(account1).createStrategy({
+                dcaInvestments: dcaStrategyPositions,
+                vaultInvestments: vaultStrategyPosition,
+                permit: await subscriptionSignature.signSubscriptionPermit(
                     await account1.getAddress(),
                     deadline,
                 ),
-                nameBioHash,
-            )
+                metadataHash: nameBioHash,
+            })
 
             expect(tx).to.be.revertedWithCustomError(strategyManager, 'Unauthorized')
         })
 
         it('if strategy uses more than 20 dca investments', async () => {
-            const investments: StrategyManager.DcaStrategyStruct[] = new Array(21)
+            const investments: StrategyManager.DcaInvestmentStruct[] = new Array(21)
                 .map(() => ({
                     // @dev percentage doesn't matter here, the investmentCount check happens before
                     percentage: 0,
@@ -129,49 +125,49 @@ describe('StrategyManager#createStrategy', () => {
                     swaps: 10,
                 }))
 
-            const tx = strategyManager.connect(account0).createStrategy(
-                investments,
-                [],
-                await subscriptionSignature.signSubscriptionPermit(
+            const tx = strategyManager.connect(account0).createStrategy({
+                dcaInvestments: investments,
+                vaultInvestments: [],
+                permit: await subscriptionSignature.signSubscriptionPermit(
                     await account0.getAddress(),
                     deadline,
                 ),
-                nameBioHash,
-            )
+                metadataHash: nameBioHash,
+            })
 
             expect(tx).to.be.revertedWithCustomError(strategyManager, 'TooManyInvestments')
         })
 
         it('if strategy uses more than 20 vault investments', async () => {
-            const investments: StrategyManager.VaultStrategyStruct[] = new Array(21)
+            const investments: StrategyManager.VaultInvestmentStruct[] = new Array(21)
                 .map(() => ({
                     // @dev percentage doesn't matter here, the investmentCount check happens before
                     percentage: 0,
                     vault: '',
                 }))
 
-            const tx = strategyManager.connect(account0).createStrategy(
-                [],
-                investments,
-                await subscriptionSignature.signSubscriptionPermit(
+            const tx = strategyManager.connect(account0).createStrategy({
+                dcaInvestments: [],
+                vaultInvestments: investments,
+                permit: await subscriptionSignature.signSubscriptionPermit(
                     await account0.getAddress(),
                     deadline,
                 ),
-                nameBioHash,
-            )
+                metadataHash: nameBioHash,
+            })
 
             expect(tx).to.be.revertedWithCustomError(strategyManager, 'TooManyInvestments')
         })
 
         it('if strategy uses more than 20 investments total', async () => {
-            const vaultInvestments: StrategyManager.VaultStrategyStruct[] = new Array(10)
+            const vaultInvestments: StrategyManager.VaultInvestmentStruct[] = new Array(10)
                 .map(() => ({
                     // @dev percentage doesn't matter here, the investmentCount check happens before
                     percentage: 0,
                     vault: '',
                 }))
 
-            const dcaInvestment: StrategyManager.DcaStrategyStruct[] = new Array(21)
+            const dcaInvestment: StrategyManager.DcaInvestmentStruct[] = new Array(21)
                 .map(() => ({
                     // @dev percentage doesn't matter here, the investmentCount check happens before
                     percentage: 0,
@@ -179,40 +175,40 @@ describe('StrategyManager#createStrategy', () => {
                     swaps: 10,
                 }))
 
-            const tx = strategyManager.connect(account0).createStrategy(
-                dcaInvestment,
-                vaultInvestments,
-                await subscriptionSignature.signSubscriptionPermit(
+            const tx = strategyManager.connect(account0).createStrategy({
+                dcaInvestments: dcaInvestment,
+                vaultInvestments: vaultInvestments,
+                permit: await subscriptionSignature.signSubscriptionPermit(
                     await account0.getAddress(),
                     deadline,
                 ),
-                nameBioHash,
-            )
+                metadataHash: nameBioHash,
+            })
 
             expect(tx).to.be.revertedWithCustomError(strategyManager, 'TooManyInvestments')
         })
 
         it('if total percentage is different than 100', async () => {
-            const tx0 = strategyManager.connect(account0).createStrategy(
-                [],
-                [],
-                await subscriptionSignature.signSubscriptionPermit(
+            const tx0 = strategyManager.connect(account0).createStrategy({
+                dcaInvestments: [],
+                vaultInvestments: [],
+                permit: await subscriptionSignature.signSubscriptionPermit(
                     await account0.getAddress(),
                     deadline,
                 ),
-                nameBioHash,
-            )
+                metadataHash: nameBioHash,
+            })
 
-            const tx1 = strategyManager.connect(account0).createStrategy(
+            const tx1 = strategyManager.connect(account0).createStrategy({
                 // 122%
-                [...dcaStrategyPositions, ...dcaStrategyPositions],
-                [],
-                await subscriptionSignature.signSubscriptionPermit(
+                dcaInvestments: [...dcaStrategyPositions, ...dcaStrategyPositions],
+                vaultInvestments: [],
+                permit: await subscriptionSignature.signSubscriptionPermit(
                     await account0.getAddress(),
                     deadline,
                 ),
-                nameBioHash,
-            )
+                metadataHash: nameBioHash,
+            })
 
             expect(tx0).to.be.revertedWithCustomError(strategyManager, 'InvalidTotalPercentage')
             expect(tx1).to.be.revertedWithCustomError(strategyManager, 'InvalidTotalPercentage')

--- a/test/StrategyManager/fixtures/base.fixture.ts
+++ b/test/StrategyManager/fixtures/base.fixture.ts
@@ -49,7 +49,6 @@ export const baseStrategyManagerFixture = async () => {
 
     await vaultManager.setVaultWhitelistStatus(await vault.getAddress(), true)
 
-    const chainId = await NetworkService.getChainId()
     const TOKEN_IN = await token.getAddress()
     const TOKEN_OUT = await weth.getAddress()
 
@@ -113,11 +112,11 @@ export const baseStrategyManagerFixture = async () => {
     ////////////////////////////////////////////////////////
     // Creating strategies to be used to create strategy //
     ///////////////////////////////////////////////////////
-    const dcaStrategyPositions: StrategyManager.DcaStrategyStruct[] = [
+    const dcaStrategyPositions: StrategyManager.DcaInvestmentStruct[] = [
         { poolId: 0, swaps: 10, percentage: 33 },
         { poolId: 1, swaps: 10, percentage: 33 },
     ]
-    const vaultStrategyPosition: StrategyManager.VaultStrategyStruct[] = [
+    const vaultStrategyPosition: StrategyManager.VaultInvestmentStruct[] = [
         {
             vault: await vault.getAddress(),
             percentage: 34,

--- a/test/StrategyManager/fixtures/create-strategy.fixture.ts
+++ b/test/StrategyManager/fixtures/create-strategy.fixture.ts
@@ -37,28 +37,28 @@ export const createStrategyFixture = async () => {
     /////////////////////////////////////////
     // Create default strategy for tests  //
     ////////////////////////////////////////
-    await strategyManager.connect(account0).createStrategy(
-        dcaStrategyPositions,
-        vaultStrategyPosition,
-        await subscriptionSignature.signSubscriptionPermit(
+    await strategyManager.connect(account0).createStrategy({
+        dcaInvestments: dcaStrategyPositions,
+        vaultInvestments: vaultStrategyPosition,
+        permit: await subscriptionSignature.signSubscriptionPermit(
             await account0.getAddress(),
             await NetworkService.getBlockTimestamp() + 10_000,
         ),
-        nameBioHash,
-    )
+        metadataHash: nameBioHash,
+    })
 
     //////////////////////////////////////////////
     // Create strategy for swap and deposit test//
     //////////////////////////////////////////////
-    await strategyManager.connect(account0).createStrategy(
-        [{ poolId: 2, swaps: 10, percentage: 66 }],
-        vaultStrategyPosition,
-        await subscriptionSignature.signSubscriptionPermit(
+    await strategyManager.connect(account0).createStrategy({
+        dcaInvestments: [{ poolId: 2, swaps: 10, percentage: 66 }],
+        vaultInvestments: vaultStrategyPosition,
+        permit: await subscriptionSignature.signSubscriptionPermit(
             await account0.getAddress(),
             await NetworkService.getBlockTimestamp() + 10_000,
         ),
-        nameBioHash,
-    )
+        metadataHash: nameBioHash,
+    })
 
     return {
         account0,

--- a/test/StrategyManager/zap.test.ts
+++ b/test/StrategyManager/zap.test.ts
@@ -161,8 +161,8 @@ describe('StrategyManager#invest (zap)', () => {
         }
 
         beforeEach(async () => {
-            await strategyManager.connect(account0).createStrategy(
-                [
+            await strategyManager.connect(account0).createStrategy({
+                dcaInvestments: [
                     {
                         poolId: stableBtcPoolId,
                         swaps: 10,
@@ -174,10 +174,10 @@ describe('StrategyManager#invest (zap)', () => {
                         percentage: 50n,
                     },
                 ],
-                [],
-                permitAccount0,
-                ZeroHash,
-            )
+                vaultInvestments: [],
+                permit: permitAccount0,
+                metadataHash: ZeroHash,
+            })
 
             await stablecoin.connect(account0).mint(account0, amount)
             await stablecoin.connect(account0).approve(strategyManager, amount)
@@ -323,9 +323,9 @@ describe('StrategyManager#invest (zap)', () => {
         beforeEach(async () => {
             initialLpBalance = await btcEthLpUniV2.balanceOf(account0)
 
-            await strategyManager.connect(account0).createStrategy(
-                [],
-                [
+            await strategyManager.connect(account0).createStrategy({
+                dcaInvestments: [],
+                vaultInvestments: [
                     {
                         vault: await createVault(wbtc),
                         percentage: 50n,
@@ -335,9 +335,9 @@ describe('StrategyManager#invest (zap)', () => {
                         percentage: 50n,
                     },
                 ],
-                permitAccount0,
-                ZeroHash,
-            )
+                permit: permitAccount0,
+                metadataHash: ZeroHash,
+            })
 
             await stablecoin.connect(account0).mint(account0, amount)
             await stablecoin.connect(account0).approve(strategyManager, amount)
@@ -462,8 +462,8 @@ describe('StrategyManager#invest (zap)', () => {
             initialLpBalance = await btcEthLpUniV2.balanceOf(account0)
             initialStablecoinBalance = await stablecoin.balanceOf(account0)
 
-            await strategyManager.connect(account0).createStrategy(
-                [
+            await strategyManager.connect(account0).createStrategy({
+                dcaInvestments: [
                     {
                         poolId: stableBtcPoolId,
                         swaps: 10,
@@ -475,7 +475,7 @@ describe('StrategyManager#invest (zap)', () => {
                         percentage: 25n,
                     },
                 ],
-                [
+                vaultInvestments: [
                     {
                         vault: await createVault(wbtc),
                         percentage: 25n,
@@ -485,9 +485,9 @@ describe('StrategyManager#invest (zap)', () => {
                         percentage: 25n,
                     },
                 ],
-                permitAccount0,
-                ZeroHash,
-            )
+                permit: permitAccount0,
+                metadataHash: ZeroHash,
+            })
 
             await stablecoin.connect(account0).mint(account0, amount)
             await stablecoin.connect(account0).approve(strategyManager, amount)


### PR DESCRIPTION
Removed `dcaInvestments` and `vaultInvestments` from the Strategy struct since Structs can't be changed on contract upgrades and moved them to a separate storage space where other investments can also be added in future iterations