### PR TITLE
[TEST]: Liquidity Fees

### DIFF
--- a/contracts/StrategyManager__v4.sol
+++ b/contracts/StrategyManager__v4.sol
@@ -69,6 +69,10 @@ contract StrategyManager__v4 is StrategyManager__v3 {
         return liquidityRewards;
     }
 
+    function getStrategistRewardFeeSplitBP() external view returns (uint32) {
+        return LiquidityStorage.getLiquidityStruct().strategistRewardFeeSplitBP;
+    }
+
     function getLiquidityRewardFee(uint _strategyId) external view returns (uint32) {
         return LiquidityStorage.getLiquidityStruct().strategiesLiquidityFeeBP[_strategyId];
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@defihub/shared": "4.0.8",
+                "@defihub/shared": "4.0.11",
                 "@nomicfoundation/hardhat-toolbox": "^5.0.0",
                 "@openzeppelin/contracts": "4.9.6",
                 "@openzeppelin/contracts-upgradeable": "4.9.6",
@@ -993,9 +993,9 @@
             }
         },
         "node_modules/@defihub/shared": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/@defihub/shared/-/shared-4.0.8.tgz",
-            "integrity": "sha512-IeZocNl/4J9vUA1FmnNMyqRrLswFraTOk//DoE8C+fcQW9D2kr6lhtYXk8jBRcj8NmYxE7TZcUkjfDMxR3zWwQ==",
+            "version": "4.0.11",
+            "resolved": "https://registry.npmjs.org/@defihub/shared/-/shared-4.0.11.tgz",
+            "integrity": "sha512-3r6hI9XJ3kvhRvCCg/D/cBG2KiAEsJ0NK+DcEbI5sgfacfG+wEr7Vee+6d/wksqO76+xu1AS+9ix5X/7gZWEgw==",
             "license": "ISC",
             "dependencies": {
                 "@ryze-blockchain/ethereum": "^2.0.9",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@defihub/shared": "4.0.8",
+        "@defihub/shared": "4.0.11",
         "@nomicfoundation/hardhat-toolbox": "^5.0.0",
         "@openzeppelin/contracts": "4.9.6",
         "@openzeppelin/contracts-upgradeable": "4.9.6",

--- a/src/helpers/create-strategy.ts
+++ b/src/helpers/create-strategy.ts
@@ -1,27 +1,28 @@
-import { StrategyManager, SubscriptionManager } from '@src/typechain'
-import { Signer, ZeroHash } from 'ethers'
+import { StrategyManager, StrategyManager__v4, SubscriptionManager } from '@src/typechain'
+import { BigNumberish, Signer, ZeroHash } from 'ethers'
 
 export async function createStrategy(
     strategist: Signer,
     permit: SubscriptionManager.PermitStruct,
-    strategyManager: StrategyManager,
+    strategyManager: StrategyManager__v4,
     {
         dcaInvestments,
         vaultInvestments,
         liquidityInvestments,
         buyInvestments,
     }: Omit<StrategyManager.CreateStrategyParamsStruct, 'permit' | 'metadataHash'>,
+    liquidityRewardFeeBP?: BigNumberish,
 ): Promise<bigint> {
     const strategyId = await strategyManager.getStrategiesLength()
 
-    await strategyManager.connect(strategist).createStrategy({
+    await strategyManager.connect(strategist).createStrategyV2({
         dcaInvestments,
         vaultInvestments,
         liquidityInvestments,
         buyInvestments,
         permit,
         metadataHash: ZeroHash,
-    })
+    }, liquidityRewardFeeBP ?? 0)
 
     return strategyId
 }

--- a/src/helpers/get-event-log.ts
+++ b/src/helpers/get-event-log.ts
@@ -1,4 +1,5 @@
 import { FeeToType } from '@defihub/shared'
+import { notEmpty } from '@ryze-blockchain/ethereum'
 import { StrategyInvestor__factory } from '@src/typechain'
 import { ContractTransactionReceipt, Interface } from 'ethers'
 import { decodeFeeEventBytes } from './test-helpers'
@@ -39,5 +40,17 @@ export function getFeeEventLog(
                     return parsedLog
             }
         }
+    }
+}
+
+export function getAllFeeEventLogs(receipt: ContractTransactionReceipt | null) {
+    const contractInterface = StrategyInvestor__factory.createInterface()
+
+    if (receipt?.logs) {
+        return receipt.logs.map(log => {
+            const parsedLog = contractInterface.parseLog(log)
+
+            return parsedLog && parsedLog.name === 'Fee' ? parsedLog : null
+        }).filter(notEmpty)
     }
 }

--- a/src/helpers/liquidity.ts
+++ b/src/helpers/liquidity.ts
@@ -195,7 +195,7 @@ export class LiquidityHelpers {
             this.getDeductedPositionFees(
                 tokenId,
                 liquidityRewardFeeBP,
-                positionManager.connect(ethers.provider),
+                positionManager,
                 from,
             ),
         ])

--- a/src/helpers/liquidity.ts
+++ b/src/helpers/liquidity.ts
@@ -16,7 +16,7 @@ import { SwapEncoder } from '@src/helpers/SwapEncoder'
 import { ONE_PERCENT } from '@src/constants'
 
 export class LiquidityHelpers {
-    private static readonly MAX_FEE = BigInt(1e6)
+    private static readonly ONE_HUNDRED_PERCENT_IN_BP = BigInt(1e6)
 
     public static getMinOutput(
         amount: bigint,
@@ -122,8 +122,8 @@ export class LiquidityHelpers {
             from,
         )
 
-        const amountMinusFees0 = amount0 - (amount0 * liquidityRewardFeeBP / this.MAX_FEE)
-        const amountMinusFees1 = amount1 - (amount1 * liquidityRewardFeeBP / this.MAX_FEE)
+        const amountMinusFees0 = amount0 - (amount0 * liquidityRewardFeeBP / this.ONE_HUNDRED_PERCENT_IN_BP)
+        const amountMinusFees1 = amount1 - (amount1 * liquidityRewardFeeBP / this.ONE_HUNDRED_PERCENT_IN_BP)
 
         return {
             amount0: amountMinusFees0,
@@ -158,10 +158,10 @@ export class LiquidityHelpers {
                 UniswapV3.getPositionFees(position.tokenId, positionManager, strategyManager),
             ])
 
-            const total0 = amount0 * strategyLiquidityFee / this.MAX_FEE
-            const total1 = amount1 * strategyLiquidityFee / this.MAX_FEE
-            const strategist0 = total0 * strategistRewardFeeSplit / this.MAX_FEE
-            const strategist1 = total1 * strategistRewardFeeSplit / this.MAX_FEE
+            const total0 = amount0 * strategyLiquidityFee / this.ONE_HUNDRED_PERCENT_IN_BP
+            const total1 = amount1 * strategyLiquidityFee / this.ONE_HUNDRED_PERCENT_IN_BP
+            const strategist0 = total0 * strategistRewardFeeSplit / this.ONE_HUNDRED_PERCENT_IN_BP
+            const strategist1 = total1 * strategistRewardFeeSplit / this.ONE_HUNDRED_PERCENT_IN_BP
             const protocol0 = total0 - strategist0
             const protocol1 = total1 - strategist1
 

--- a/src/helpers/liquidity.ts
+++ b/src/helpers/liquidity.ts
@@ -109,28 +109,6 @@ export class LiquidityHelpers {
         }
     }
 
-    // TODO update on shared (UniswapV3.getPositionFees)
-    public static async getDeductedPositionFees(
-        tokenId: bigint,
-        liquidityRewardFeeBP: bigint,
-        positionManager: NonFungiblePositionManager,
-        from: AddressLike,
-    ): Promise<{ amount0: bigint, amount1: bigint }> {
-        const { amount0, amount1 } = await UniswapV3.getPositionFees(
-            tokenId,
-            positionManager.connect(ethers.provider),
-            from,
-        )
-
-        const amountMinusFees0 = amount0 - (amount0 * liquidityRewardFeeBP / this.ONE_HUNDRED_PERCENT_IN_BP)
-        const amountMinusFees1 = amount1 - (amount1 * liquidityRewardFeeBP / this.ONE_HUNDRED_PERCENT_IN_BP)
-
-        return {
-            amount0: amountMinusFees0,
-            amount1: amountMinusFees1,
-        }
-    }
-
     public static async getPositionFeeAmounts(
         strategyId: bigint,
         positionId: bigint,
@@ -194,10 +172,10 @@ export class LiquidityHelpers {
             fees,
         ] = await Promise.all([
             positionManager.positions(tokenId),
-            this.getDeductedPositionFees(
+            UniswapV3.getDeductedPositionFees(
                 tokenId,
                 liquidityRewardFeeBP,
-                positionManager,
+                positionManager.connect(ethers.provider),
                 from,
             ),
         ])

--- a/src/helpers/liquidity.ts
+++ b/src/helpers/liquidity.ts
@@ -167,8 +167,10 @@ export class LiquidityHelpers {
 
             return {
                 tokens: [token0, token1],
-                [FeeTo.PROTOCOL]: [protocol0, protocol1],
-                [FeeTo.STRATEGIST]: [strategist0, strategist1],
+                amountsByFeeTo: {
+                    [FeeTo.PROTOCOL]: [protocol0, protocol1],
+                    [FeeTo.STRATEGIST]: [strategist0, strategist1],
+                },
             }
         }))
     }

--- a/src/helpers/test-helpers.ts
+++ b/src/helpers/test-helpers.ts
@@ -202,9 +202,10 @@ export async function getRewardsDistributionFeeEvents(
     const expectedEvents: FeeEvent.OutputTuple[] = []
 
     for (const fees of positionsFees) {
-        // Fee events are emitted first to strategist then to protocol
+        // When distributing liquidity rewards, Fee events are emitted first to
+        // strategist and then to the protocol
         for (const feeTo of [FeeTo.STRATEGIST, FeeTo.PROTOCOL]) {
-            // Generate event for each token
+            // Generate Fee event for each token
             for (let index = 0; index < fees.tokens.length; index++) {
                 expectedEvents.push([
                     investorAddress,

--- a/src/helpers/test-helpers.ts
+++ b/src/helpers/test-helpers.ts
@@ -35,6 +35,22 @@ export async function getAccountBalanceMap(
     return tokenBalanceMap
 }
 
+export async function getAccountRewardsMap(
+    account: Signer,
+    tokens: Set<string>,
+    strategyManager: StrategyManager__v4,
+) {
+    const liquidityRewardsMap: Record<string, bigint> = {}
+
+    await Promise.all(
+        Array.from(tokens).map(async token => {
+            liquidityRewardsMap[token] = await strategyManager.getRewards(account, token)
+        }),
+    )
+
+    return liquidityRewardsMap
+}
+
 export async function getStrategyBalanceMap(
     strategyManager: StrategyManager__v4,
     dca: DollarCostAverage,

--- a/test/StrategyManager/closePosition.test.ts
+++ b/test/StrategyManager/closePosition.test.ts
@@ -167,7 +167,7 @@ describe('StrategyManager#closePosition', () => {
         })
     })
 
-    describe.only('Given an open position with only liquidity', () => {
+    describe('Given an open position with only liquidity', () => {
         describe('When the owner of position calls closePosition', () => {
             it('Then liquidity reward fees are distributed to strategist and treasury', async () => {
                 const positionsFees = await LiquidityHelpers.getPositionFeeAmounts(

--- a/test/StrategyManager/closePosition.test.ts
+++ b/test/StrategyManager/closePosition.test.ts
@@ -21,6 +21,7 @@ import {
     getAccountRewardsMap,
     getRewardsDistributionFeeEvents,
     getAllFeeEventLogs,
+    mapPositionsFeesByFeeToAndToken,
 } from '@src/helpers'
 
 /*
@@ -175,23 +176,9 @@ describe('StrategyManager#closePosition', () => {
                     account1,
                     strategyManager,
                 )
+
                 const tokens = new Set(positionsFees.flatMap(fees => fees.tokens))
-
-                const feesByFeeToAndToken = positionsFees.reduce<Record<number, Record<string, bigint>>>((acc, fees) => {
-                    for (let index = 0; index < fees.tokens.length; index++) {
-                        const token = fees.tokens[index]
-                        const protocolFee = fees[FeeTo.PROTOCOL][index]
-                        const strategistFee = fees[FeeTo.STRATEGIST][index]
-
-                        acc[FeeTo.PROTOCOL][token] = (acc[FeeTo.PROTOCOL][token] || BigInt(0)) + protocolFee
-                        acc[FeeTo.STRATEGIST][token] = (acc[FeeTo.STRATEGIST][token] || BigInt(0)) + strategistFee
-                    }
-
-                    return acc
-                }, {
-                    [FeeTo.PROTOCOL]: {},
-                    [FeeTo.STRATEGIST]: {},
-                })
+                const feesByFeeToAndToken = mapPositionsFeesByFeeToAndToken(positionsFees)
 
                 const [
                     treasuryRewardBalancesBefore,

--- a/test/StrategyManager/collectPosition.test.ts
+++ b/test/StrategyManager/collectPosition.test.ts
@@ -20,6 +20,7 @@ import {
     getAllFeeEventLogs,
     getAccountRewardsMap,
     getRewardsDistributionFeeEvents,
+    mapPositionsFeesByFeeToAndToken,
 } from '@src/helpers'
 import { FeeTo } from '@defihub/shared'
 
@@ -169,23 +170,9 @@ describe('StrategyManager#collectPosition', () => {
                         account1,
                         strategyManager,
                     )
+
                     const tokens = new Set(positionsFees.flatMap(fees => fees.tokens))
-
-                    const feesByFeeToAndToken = positionsFees.reduce<Record<number, Record<string, bigint>>>((acc, fees) => {
-                        for (let index = 0; index < fees.tokens.length; index++) {
-                            const token = fees.tokens[index]
-                            const protocolFee = fees[FeeTo.PROTOCOL][index]
-                            const strategistFee = fees[FeeTo.STRATEGIST][index]
-
-                            acc[FeeTo.PROTOCOL][token] = (acc[FeeTo.PROTOCOL][token] || BigInt(0)) + protocolFee
-                            acc[FeeTo.STRATEGIST][token] = (acc[FeeTo.STRATEGIST][token] || BigInt(0)) + strategistFee
-                        }
-
-                        return acc
-                    }, {
-                        [FeeTo.PROTOCOL]: {},
-                        [FeeTo.STRATEGIST]: {},
-                    })
+                    const feesByFeeToAndToken = mapPositionsFeesByFeeToAndToken(positionsFees)
 
                     const [
                         treasuryRewardBalancesBefore,

--- a/test/StrategyManager/collectPosition.test.ts
+++ b/test/StrategyManager/collectPosition.test.ts
@@ -1,4 +1,7 @@
 import { expect } from 'chai'
+import { Signer } from 'ethers'
+import { ethers } from 'hardhat'
+import { FeeTo, UniswapV3 } from '@defihub/shared'
 import { loadFixture } from '@nomicfoundation/hardhat-toolbox/network-helpers'
 import {
     DollarCostAverage,
@@ -8,7 +11,6 @@ import {
     UniswapPositionManager,
     UniswapV3Factory,
 } from '@src/typechain'
-import {  Signer } from 'ethers'
 import { runStrategy } from './fixtures/run-strategy.fixture'
 import {
     expectCustomError,
@@ -22,7 +24,6 @@ import {
     getRewardsDistributionFeeEvents,
     mapPositionsFeesByFeeToAndToken,
 } from '@src/helpers'
-import { FeeTo } from '@defihub/shared'
 
 /*
     => Given an investor with a position in a strategy
@@ -227,10 +228,10 @@ describe('StrategyManager#collectPosition', () => {
 
                     const liquidityWithdrawAmounts = await Promise.all(
                         investments.liquidityPositions.map(async position => {
-                            const { amount0, amount1 } = await LiquidityHelpers.getDeductedPositionFees(
+                            const { amount0, amount1 } = await UniswapV3.getDeductedPositionFees(
                                 position.tokenId,
                                 liquidityRewardFeeBP,
-                                positionManagerUniV3,
+                                positionManagerUniV3.connect(ethers.provider),
                                 strategyManager,
                             )
 

--- a/test/StrategyManager/collectRewards.test.ts
+++ b/test/StrategyManager/collectRewards.test.ts
@@ -1,0 +1,160 @@
+import hre from 'hardhat'
+import { expect } from 'chai'
+import { parseEther, Signer } from 'ethers'
+import { loadFixture } from '@nomicfoundation/hardhat-toolbox/network-helpers'
+import { PathUniswapV3, RoutePlanner, UniversalRouterCommand, unwrapAddressLike } from '@defihub/shared'
+import { StrategyManager__v4, TestERC20, UniversalRouter } from '@src/typechain'
+import { runStrategy } from './fixtures/run-strategy.fixture'
+
+/*
+    => when collectRewards method is called
+        => if user does not have any rewards to collect, then it does nothing
+        => if user has rewards to collect
+            => if token is stable
+                => then collect rewards from all sources
+                => then transfer rewards to msg.sender
+                => then emit CollectedRewards event
+            => if token is not stable
+                => then collect rewards ONLY from liquidity fees
+                => then transfer rewards to msg.sender
+                => then emit CollectedRewards event
+
+    => when collectManyRewards method is called
+        => TODO
+*/
+describe('StrategyManager#collectRewards', () => {
+    let strategyManager: StrategyManager__v4
+    let account0: Signer
+    let account1: Signer
+
+    let weth: TestERC20
+    let stablecoin: TestERC20
+
+    let liquidityPositionId: bigint
+    let universalRouter: UniversalRouter
+
+    beforeEach(async () => {
+        ({
+            strategyManager,
+            account0,
+            account1,
+            weth,
+            stablecoin,
+            liquidityPositionId,
+            universalRouter,
+        } = await loadFixture(runStrategy))
+    })
+
+    describe('when collectRewards method is called', () => {
+        it('if user does not have any rewards to collect, then it does nothing', async () => {
+            expect(await strategyManager.getRewards(account1, weth)).to.equal(0)
+
+            await expect(strategyManager.connect(account1).collectRewards(weth))
+                .to.not.emit(strategyManager, 'CollectedRewards')
+        })
+
+        describe('if user has rewards to collect', () => {
+            describe('if token is stable', () => {
+                it('then collect rewards from all sources', async () => {
+                    const toCollect = await strategyManager.getRewards(account0, stablecoin)
+                    const strategistRewards = await strategyManager.getStrategistRewards(account0)
+
+                    expect(toCollect).to.greaterThan(0)
+                    expect(strategistRewards).to.be.greaterThan(0)
+
+                    await strategyManager.connect(account0).collectRewards(stablecoin)
+
+                    expect(await strategyManager.getStrategistRewards(account0)).to.equal(0)
+                    expect(await strategyManager.getRewards(account0, stablecoin)).to.equal(0)
+                })
+
+                it('then transfer rewards to msg.sender', async () => {
+                    const balanceBefore = await stablecoin.balanceOf(account0)
+                    const toCollect = await strategyManager.getRewards(account0, stablecoin)
+
+                    await strategyManager.connect(account0).collectRewards(stablecoin)
+
+                    const balanceDelta = (await stablecoin.balanceOf(account0)) - balanceBefore
+
+                    expect(toCollect).to.be.greaterThan(0)
+                    expect(balanceDelta).to.equal(toCollect)
+                })
+
+                it('then emit CollectedRewards event', async () => {
+                    const toCollect = await strategyManager.getRewards(account0, stablecoin)
+
+                    await expect(strategyManager.connect(account0).collectRewards(stablecoin))
+                        .to.emit(strategyManager, 'CollectedRewards')
+                        .withArgs(account0, stablecoin, toCollect)
+                })
+            })
+
+            describe('if token is not stable', () => {
+                // Make a swap to generate liquidity fees
+                beforeEach(async () => {
+                    const ONE_ETH = parseEther('10')
+                    const [swapper] = await hre.ethers.getSigners()
+                    const planner = new RoutePlanner(await unwrapAddressLike(universalRouter))
+
+                    planner.addCommand(
+                        UniversalRouterCommand.V3_SWAP_EXACT_IN,
+                        [
+                            await swapper.getAddress(),
+                            ONE_ETH,
+                            ONE_ETH - parseEther('0.01'),
+                            (await PathUniswapV3.fromAddressLike(
+                                weth,
+                                [{ token: stablecoin, fee: 3000 }],
+                            )).encodedPath(),
+                            false,
+                        ],
+                    )
+
+                    await weth.connect(swapper).mint(swapper, ONE_ETH)
+                    await weth.connect(swapper).transfer(universalRouter, ONE_ETH)
+                    await universalRouter.connect(swapper)['execute(bytes,bytes[])'](
+                        planner.commands,
+                        planner.inputs,
+                    )
+
+                    // Collect position that has liquidity fees to generate rewards
+                    await strategyManager.connect(account1).collectPosition(liquidityPositionId)
+                })
+
+                it('then collect rewards ONLY from liquidity fees', async () => {
+                    const wethToCollect = await strategyManager.getRewards(account0, weth)
+                    const stableToCollect = await strategyManager.getRewards(account0, stablecoin)
+
+                    expect(wethToCollect).to.be.greaterThan(0)
+                    expect(stableToCollect).to.be.greaterThan(0)
+
+                    await strategyManager.connect(account0).collectRewards(weth)
+
+                    expect(await strategyManager.getRewards(account0, weth)).to.equal(0)
+                    expect(await strategyManager.getRewards(account0, stablecoin)).to.equal(stableToCollect)
+                })
+
+                it('then transfer rewards to msg.sender', async () => {
+                    const balanceBefore = await weth.balanceOf(account0)
+                    const toCollect = await strategyManager.getRewards(account0, weth)
+
+                    await strategyManager.connect(account0).collectRewards(weth)
+
+                    const balanceDelta = (await weth.balanceOf(account0)) - balanceBefore
+
+                    expect(toCollect).to.be.greaterThan(0)
+                    expect(balanceDelta).to.equal(toCollect)
+                })
+
+                it('then emit CollectedRewards event', async () => {
+                    const toCollect = await strategyManager.getRewards(account0, weth)
+
+                    await expect(strategyManager.connect(account0).collectRewards(weth))
+                        .to.emit(strategyManager, 'CollectedRewards')
+                        .withArgs(account0, weth, toCollect)
+                })
+            })
+        })
+    })
+})
+

--- a/test/StrategyManager/createStrategy.test.ts
+++ b/test/StrategyManager/createStrategy.test.ts
@@ -1,32 +1,47 @@
 import { expect } from 'chai'
 import { Signer, keccak256, ContractTransactionResponse, ZeroAddress } from 'ethers'
-import { StrategyManager__v2 } from '@src/typechain'
+import { StrategyManager__v4 } from '@src/typechain'
 import { StrategyStorage } from '@src/typechain/artifacts/contracts/StrategyManager'
 import { SubscriptionSignature } from '@src/SubscriptionSignature'
 import { NetworkService } from '@src/NetworkService'
 import { loadFixture } from '@nomicfoundation/hardhat-toolbox/network-helpers'
 import { baseStrategyManagerFixture } from './fixtures/base.fixture'
 
-// EFFECTS
-// => creates new strategy
-// => emit StrategyCreated
-//
-// SIDE-EFFECTS
-// => increases strategy count
-//
-// REVERTS
-// => if msg.sender doesn't have an active subscription
-// => if strategy uses more than 20 investments
-// => if vault used by strategy doesn't belong to DeFihub
+/*
+    EFFECTS
+    => when createStrategy method is called
+        => creates new strategy
+        => emit StrategyCreated event
+
+    => when createStrategyV2 method is called
+        => creates new strategy
+        => emit StrategyCreated event
+        => set liquidity reward fee
+        => emit LiquidityRewardFeeSet event
+
+    SIDE-EFFECTS
+    => increase strategy count
+
+    REVERTS
+    => if msg.sender doesn't have an active subscription
+    => if strategy uses more than 20 investments
+    => if vault used by strategy doesn't belong to DeFihub
+    => if liquidity reward fee is too high
+*/
 describe('StrategyManager#createStrategy', () => {
     let account0: Signer
     let account1: Signer
-    let strategyManager: StrategyManager__v2
+    let strategyManager: StrategyManager__v4
     let dcaStrategyPositions: StrategyStorage.DcaInvestmentStruct[]
     let vaultStrategyPosition: StrategyStorage.VaultInvestmentStruct[]
     let subscriptionSignature: SubscriptionSignature
     let deadline: number
+
     const metadataHash = keccak256(new TextEncoder().encode('Name' + 'Bio'))
+
+    function percentageToBP(percentage: number): bigint {
+        return BigInt(percentage * 1e6 / 100)
+    }
 
     beforeEach(async () => {
         ({
@@ -42,47 +57,111 @@ describe('StrategyManager#createStrategy', () => {
     })
 
     describe('EFFECTS', async () => {
-        let tx: Promise<ContractTransactionResponse>
+        describe('when createStrategy method is called', () => {
+            let tx: Promise<ContractTransactionResponse>
 
-        beforeEach(async () => {
-            tx = strategyManager.connect(account0).createStrategy({
-                dcaInvestments: dcaStrategyPositions,
-                vaultInvestments: vaultStrategyPosition,
-                liquidityInvestments: [],
-                buyInvestments: [],
-                permit: await subscriptionSignature.signSubscriptionPermit(
-                    await account0.getAddress(),
-                    await NetworkService.getBlockTimestamp() + 10_000,
-                ),
-                metadataHash,
+            beforeEach(async () => {
+                tx = strategyManager.connect(account0).createStrategy({
+                    dcaInvestments: dcaStrategyPositions,
+                    vaultInvestments: vaultStrategyPosition,
+                    liquidityInvestments: [],
+                    buyInvestments: [],
+                    permit: await subscriptionSignature.signSubscriptionPermit(
+                        await account0.getAddress(),
+                        deadline,
+                    ),
+                    metadataHash,
+                })
+            })
+
+            it('creates new strategy', async () => {
+                await tx
+
+                const investments = await strategyManager.getStrategyInvestments(0)
+
+                expect(investments.dcaInvestments[0].swaps).to.be.equal(dcaStrategyPositions[0].swaps)
+                expect(investments.dcaInvestments[0].poolId).to.be.equal(dcaStrategyPositions[0].poolId)
+                expect(investments.dcaInvestments[0].percentage).to.be.equal(dcaStrategyPositions[0].percentage)
+
+                expect(investments.dcaInvestments[1].swaps).to.be.equal(dcaStrategyPositions[1].swaps)
+                expect(investments.dcaInvestments[1].poolId).to.be.equal(dcaStrategyPositions[1].poolId)
+                expect(investments.dcaInvestments[1].percentage).to.be.equal(dcaStrategyPositions[1].percentage)
+
+                expect(investments.vaultInvestments[0].vault).to.be.equal(vaultStrategyPosition[0].vault)
+                expect(investments.vaultInvestments[0].percentage).to.be.equal(vaultStrategyPosition[0].percentage)
+            })
+
+            it('emit StrategyCreated event', async () => {
+                await expect(tx)
+                    .to.emit(strategyManager, 'StrategyCreated')
+                    .withArgs(
+                        await account0.getAddress(),
+                        0,
+                        metadataHash,
+                    )
             })
         })
 
-        it('creates new strategy', async () => {
-            await tx
+        describe('when createStrategyV2 method is called', () => {
+            let tx: Promise<ContractTransactionResponse>
+            const defaultLiquidityRewardFeeBP = percentageToBP(5)
 
-            const investments = await strategyManager.getStrategyInvestments(0)
-
-            expect(investments.dcaInvestments[0].swaps).to.be.equal(dcaStrategyPositions[0].swaps)
-            expect(investments.dcaInvestments[0].poolId).to.be.equal(dcaStrategyPositions[0].poolId)
-            expect(investments.dcaInvestments[0].percentage).to.be.equal(dcaStrategyPositions[0].percentage)
-
-            expect(investments.dcaInvestments[1].swaps).to.be.equal(dcaStrategyPositions[1].swaps)
-            expect(investments.dcaInvestments[1].poolId).to.be.equal(dcaStrategyPositions[1].poolId)
-            expect(investments.dcaInvestments[1].percentage).to.be.equal(dcaStrategyPositions[1].percentage)
-
-            expect(investments.vaultInvestments[0].vault).to.be.equal(vaultStrategyPosition[0].vault)
-            expect(investments.vaultInvestments[0].percentage).to.be.equal(vaultStrategyPosition[0].percentage)
-        })
-
-        it('emit StrategyCreated', async () => {
-            await expect(tx)
-                .to.emit(strategyManager, 'StrategyCreated')
-                .withArgs(
-                    await account0.getAddress(),
-                    0,
+            beforeEach(async () => {
+                tx = strategyManager.connect(account0).createStrategyV2({
+                    dcaInvestments: dcaStrategyPositions,
+                    vaultInvestments: vaultStrategyPosition,
+                    liquidityInvestments: [],
+                    buyInvestments: [],
+                    permit: await subscriptionSignature.signSubscriptionPermit(
+                        await account0.getAddress(),
+                        deadline,
+                    ),
                     metadataHash,
-                )
+                }, defaultLiquidityRewardFeeBP)
+            })
+
+            it('creates new strategy', async () => {
+                await tx
+
+                const investments = await strategyManager.getStrategyInvestments(0)
+
+                expect(investments.dcaInvestments[0].swaps).to.be.equal(dcaStrategyPositions[0].swaps)
+                expect(investments.dcaInvestments[0].poolId).to.be.equal(dcaStrategyPositions[0].poolId)
+                expect(investments.dcaInvestments[0].percentage).to.be.equal(dcaStrategyPositions[0].percentage)
+
+                expect(investments.dcaInvestments[1].swaps).to.be.equal(dcaStrategyPositions[1].swaps)
+                expect(investments.dcaInvestments[1].poolId).to.be.equal(dcaStrategyPositions[1].poolId)
+                expect(investments.dcaInvestments[1].percentage).to.be.equal(dcaStrategyPositions[1].percentage)
+
+                expect(investments.vaultInvestments[0].vault).to.be.equal(vaultStrategyPosition[0].vault)
+                expect(investments.vaultInvestments[0].percentage).to.be.equal(vaultStrategyPosition[0].percentage)
+            })
+
+            it('emit StrategyCreated event', async () => {
+                await expect(tx)
+                    .to.emit(strategyManager, 'StrategyCreated')
+                    .withArgs(
+                        await account0.getAddress(),
+                        0, // Strategy ID
+                        metadataHash,
+                    )
+            })
+
+            it('set liquidity reward fee', async () => {
+                await tx
+
+                expect(await strategyManager.getLiquidityRewardFee(0))
+                    .to.be.equal(defaultLiquidityRewardFeeBP)
+            })
+
+            it('emit LiquidityRewardFeeSet event', async () => {
+                await expect(tx)
+                    .to.emit(strategyManager, 'LiquidityRewardFeeSet')
+                    .withArgs(
+                        0, // Strategy ID
+                        defaultLiquidityRewardFeeBP,
+                    )
+            })
         })
     })
 
@@ -237,6 +316,25 @@ describe('StrategyManager#createStrategy', () => {
             })
 
             await expect(tx1).to.be.revertedWithCustomError(strategyManager, 'InvalidTotalPercentage')
+        })
+
+        it('if liquidity reward fee BP is too high', async () => {
+            const feeAboveLimitBP = percentageToBP(25.01)
+
+            const tx = strategyManager.connect(account0).createStrategyV2({
+                dcaInvestments: dcaStrategyPositions,
+                vaultInvestments: vaultStrategyPosition,
+                liquidityInvestments: [],
+                buyInvestments: [],
+                permit: await subscriptionSignature.signSubscriptionPermit(
+                    await account0.getAddress(),
+                    deadline,
+                ),
+                metadataHash,
+            }, feeAboveLimitBP)
+
+            await expect(tx)
+                .to.be.revertedWithCustomError(strategyManager, 'FeeTooHigh')
         })
     })
 })

--- a/test/StrategyManager/fixtures/invest.fixture.ts
+++ b/test/StrategyManager/fixtures/invest.fixture.ts
@@ -75,6 +75,7 @@ export async function investFixture() {
             ],
             buyInvestments: [],
         },
+        10_000, // 1% liquidity reward fee in BP
     )
     const buyOnlyStrategyId = await createStrategy(
         account0,
@@ -202,6 +203,7 @@ export async function investFixture() {
         permitAccount0,
         factoryUniV3,
         positionManagerUniV3,
+        universalRouter,
         ...rest,
     }
 }

--- a/test/StrategyManager/upgrade.test.ts
+++ b/test/StrategyManager/upgrade.test.ts
@@ -1,11 +1,11 @@
 import { expect } from 'chai'
-import { parseEther, Signer } from 'ethers'
+import { parseEther, Signer, ZeroHash } from 'ethers'
 import { PathUniswapV3, Fees } from '@defihub/shared'
 import { BigNumber } from '@ryze-blockchain/ethereum'
 
 import { Compare } from '@src/Compare'
 import { ProjectDeployer } from '@src/ProjectDeployer'
-import { createStrategy, SwapEncoder, UniswapV3 } from '@src/helpers'
+import { SwapEncoder, UniswapV3 } from '@src/helpers'
 import { ETH_PRICE, ETH_PRICE_BN, ETH_QUOTE, ONE_PERCENT, USD_PRICE_BN, USD_QUOTE } from '@src/constants'
 import {
     StrategyManager,
@@ -133,12 +133,13 @@ describe('StrategyManager#upgrade', () => {
             buyInvestments: [{ percentage: 100, token: weth }],
         }
 
-        strategyId = await createStrategy(
-            account0,
-            permitAccount0,
-            strategyManagerV1,
-            investments,
-        )
+        strategyId = await strategyManagerV1.getStrategiesLength()
+
+        await strategyManagerV1.connect(account0).createStrategy({
+            ...investments,
+            permit: permitAccount0,
+            metadataHash: ZeroHash,
+        })
 
         //////////////////////////////////
         // Add liquidity to make swaps //


### PR DESCRIPTION
# ABOUT
In the following list are the tests added in this PR:

`create strategy v2`
	-> should set liquidity reward fee
	-> should emit `LiquidityRewardFeeSet` event
	-> should revert if reward fee too high

`collectRewards`
	-> should collect rewards ONLY from liquidity fees if `token != stable`
	-> should collect rewards from all sources if `token == stable`
	-> should transfer rewards to sender
	-> should emit `CollectedRewards` event
	-> should do nothing if the reward amount is zero

`collectPosition`
	-> should distribute ONLY liquidity rewards (if available) to treasury and strategist
	-> should emit `Fee` event to treasury and strategist

`closePosition`
	-> should distribute ONLY liquidity rewards (if available) to treasury and strategist
	-> should emit `Fee` event to treasury and strategist